### PR TITLE
Do not call opcache functions when opcache.restrict_api is enabled

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -29,7 +29,8 @@ class Helper
      */
     public static function resetOpCache()
     {
-        if (function_exists('opcache_reset')
+        if (!ini_get('opcache.restrict_api')
+            && function_exists('opcache_reset')
             && function_exists('opcache_get_status')
             && !empty(opcache_get_status()['opcache_enabled'])
         ) {


### PR DESCRIPTION
There are some environments where `opcache.restrict_api`(https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.restrict-api) is enabled for security/stability reasons. Using them produce PHP warnings

```
qente:tmp alex$ php -dopcache.restrict_api=1 -r 'require "vendor/typo3/phar-stream-wrapper/src/Helper.php";\TYPO3\PharStreamWrapper\Helper::resetOpCache();'

PHP Warning:  Zend OPcache API is restricted by "restrict_api" configuration directive in /tmp/vendor/typo3/phar-stream-wrapper/src/Helper.php on line 34

Warning: Zend OPcache API is restricted by "restrict_api" configuration directive in /tmp/vendor/typo3/phar-stream-wrapper/src/Helper.php on line 34
```